### PR TITLE
Feature/arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ let spy = sinon.spy()
 Test(<TestComponent onClick={spy}/>)
 .use(Find, 'button')
 .use(Simulate, {method: 'click', element: 'button'})
-.test(function() {
+.test(() => {
   expect(spy.called).to.be.true
 })
 ~~~
@@ -44,6 +44,13 @@ export default function setState(state){
 
 ##test
 
-The `.test` function will be given the component instance and the helpers array. You can't use an arrow function.
+The `.test` function will be given the component instance and the helpers array. You can use a regular function to reference `this` or an arrow function:
+
+~~~js
+.test(({helpers, component}) => { ... })
+.test(function() {
+  //this.component, this.helpers
+})
+~~~
 
 You can see more examples in the tests directory.

--- a/lib/legit-tests.js
+++ b/lib/legit-tests.js
@@ -37,11 +37,7 @@ var Test = (function () {
   }, {
     key: 'test',
     value: function test(callback) {
-      var data = {
-        component: this.component,
-        helpers: this.helpers
-      };
-      callback.call(data, data);
+      callback.call(this, this);
       return this;
     }
   }]);

--- a/lib/legit-tests.js
+++ b/lib/legit-tests.js
@@ -37,10 +37,11 @@ var Test = (function () {
   }, {
     key: 'test',
     value: function test(callback) {
-      callback.call({
+      var data = {
         component: this.component,
         helpers: this.helpers
-      });
+      };
+      callback.call(data, data);
       return this;
     }
   }]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legit-tests",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "a chainable testing library for React",
   "main": "lib/legit-tests.js",
   "scripts": {

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -16,10 +16,11 @@ class Test {
   }
 
   test(callback) {
-    callback.call({
+    let data = {
       component: this.component,
       helpers: this.helpers
-    })
+    }
+    callback.call(data, data)
     return this
   }
 

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -16,11 +16,7 @@ class Test {
   }
 
   test(callback) {
-    let data = {
-      component: this.component,
-      helpers: this.helpers
-    }
-    callback.call(data, data)
+    callback.call(this, this)
     return this
   }
 

--- a/tests/setState.jsx
+++ b/tests/setState.jsx
@@ -13,8 +13,8 @@ describe('setState middleware', () => {
     Test(<TestComponent/>)
     .use(SetState, {test: 'test'})
     .use(Find, 'div')
-    .test(function() {
-      expect(this.helpers.elements.div.props.children).to.be.equal('test')
+    .test(({helpers}) => {
+      expect(helpers.elements.div.props.children).to.be.equal('test')
     })
     .use(SetState, {test: 'changed!'})
     .test(function() {

--- a/tests/simulate.jsx
+++ b/tests/simulate.jsx
@@ -15,7 +15,7 @@ describe('simulate middleware', () => {
     Test(<TestComponent onClick={spy}/>)
     .use(Find, 'div')
     .use(Simulate, {method: 'click', element: 'div'})
-    .test(function() {
+    .test(() => {
       expect(spy.called).to.be.true;
     })
 


### PR DESCRIPTION
Would love some feedback, this allows you to use arrow functions vs using `this`

~~~js
.test(({helpers}) => {

})

.test(({component}) => {

})
//can be either order
.test(({helpers, component}) => { 

})
~~~

or would you rather see me pass it separately? 

~~~js
.test(component => {

})
//but would be more complicated if you used both or if you just wanted the second argument
.test((component,helpers) => {

})
~~~