### PR TITLE
jsdom

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,0 +1,21 @@
+/* globals global */
+'use strict';
+
+function propagateToGlobal(window) {
+  for (var key in window) {
+    if (!window.hasOwnProperty(key)) continue;
+    if (key in global) continue;
+
+    global[key] = window[key];
+  }
+}
+
+var jsdom = require('jsdom');
+
+var doc = jsdom.jsdom('<!doctype html><html><body></body></html>');
+var win = doc.defaultView;
+
+global.document = doc;
+global.window = win;
+
+propagateToGlobal(win);

--- a/lib/legit-tests.js
+++ b/lib/legit-tests.js
@@ -1,3 +1,4 @@
+/* globals global */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -12,11 +13,16 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
+require('./dom');
+
 var _reactAddons = require('react/addons');
 
 var _reactAddons2 = _interopRequireDefault(_reactAddons);
 
 var TestUtils = _reactAddons2['default'].addons.TestUtils;
+
+global.React = _reactAddons2['default']; //expose React to tests so they can use jsx syntax when passing in components to the class
+require('react/lib/ExecutionEnvironment').canUseDOM = true;
 
 var Test = (function () {
   function Test(component) {

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,4 +1,3 @@
---require ./tests/setup
 --full-trace
 --compilers js:babel/register
 --recursive ./tests/**/*.jsx

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "webpack-dev-server": "^1.10.1"
   },
   "dependencies": {
+    "jsdom": "^6.5.0",
     "react": "^0.13.3"
   }
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,9 +1,4 @@
 /* globals global */
-
-require("babel/register")({
-  stage: 0
-});
-
 function propagateToGlobal (window) {
   for (let key in window) {
     if (!window.hasOwnProperty(key)) continue

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -1,5 +1,9 @@
+/* globals global */
+import './dom'
 import React from 'react/addons';
 let { TestUtils } = React.addons
+global.React = React //expose React to tests so they can use jsx syntax when passing in components to the class
+require('react/lib/ExecutionEnvironment').canUseDOM = true
 
 class Test {
 

--- a/tests/find.jsx
+++ b/tests/find.jsx
@@ -1,11 +1,9 @@
-import React from 'react'
+import Test from '../src/legit-tests'
+import {Find} from '../src/middleware'
 import { expect } from 'chai';
 
 import TestComponent from './component'
 import TinyComponent from './tiny-component'
-
-import Test from '../src/legit-tests'
-import {Find} from '../src/middleware'
 
 describe('Find middleware', () => {
 

--- a/tests/setState.jsx
+++ b/tests/setState.jsx
@@ -1,16 +1,13 @@
-import React from 'react'
-import { expect } from 'chai';
-
-import TestComponent from './component'
-
 import Test from '../src/legit-tests'
+import { expect } from 'chai';
+import TestComponent from './component'
 import {SetState, Find} from '../src/middleware'
 
 
 describe('setState middleware', () => {
 
   it('should change state', () => {
-    Test(<TestComponent/>)
+    Test(<TestComponent />)
     .use(SetState, {test: 'test'})
     .use(Find, 'div')
     .test(({helpers}) => {

--- a/tests/simulate.jsx
+++ b/tests/simulate.jsx
@@ -1,11 +1,9 @@
-import React from 'react'
-import { expect } from 'chai';
-import sinon from 'sinon';
-
-import TestComponent from './component'
-
 import Test from '../src/legit-tests'
 import {Find, Simulate} from '../src/middleware'
+import { expect } from 'chai';
+import sinon from 'sinon';
+import TestComponent from './component'
+
 
 describe('simulate middleware', () => {
 


### PR DESCRIPTION
Adding this means, there's no need for you to include jsdom in a setup file every time you write tests. This has a few hacks and things to make testing easier. I need feedback.

* monkey patch canUseDom due to the way react is loaded so that it is always true.
* expose React so that in tests you do not need to import React in order to use jsx syntax, ex : `Test(<Component/>)`
* jsdom is now a dependency of course.
* You must import this at the top of every test file for it work work correctly, or at least before you import middleware

I think that's all

fixes #3 

Oh and moving to React .14 will be only a small pain I hope :D