### PR TITLE
added native middleware

### DIFF
--- a/lib/legit-tests.js
+++ b/lib/legit-tests.js
@@ -16,6 +16,8 @@ var _reactAddons = require('react/addons');
 
 var _reactAddons2 = _interopRequireDefault(_reactAddons);
 
+var _middleware = require('./middleware');
+
 var TestUtils = _reactAddons2['default'].addons.TestUtils;
 
 var Test = (function () {
@@ -38,6 +40,27 @@ var Test = (function () {
     key: 'test',
     value: function test(callback) {
       callback.call(this, this);
+      return this;
+    }
+
+    //Built in middleware
+
+  }, {
+    key: 'find',
+    value: function find(data) {
+      _middleware.Find.call(this, data);
+      return this;
+    }
+  }, {
+    key: 'setState',
+    value: function setState(data) {
+      _middleware.SetState.call(this, data);
+      return this;
+    }
+  }, {
+    key: 'simulate',
+    value: function simulate(data) {
+      _middleware.Simulate.call(this, data);
       return this;
     }
   }]);

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -1,6 +1,8 @@
 import React from 'react/addons';
 let { TestUtils } = React.addons
 
+import {Find, SetState, Simulate} from './middleware'
+
 class Test {
 
   constructor(component){
@@ -17,6 +19,23 @@ class Test {
 
   test(callback) {
     callback.call(this, this)
+    return this
+  }
+
+  //Built in middleware
+
+  find(data){
+    Find.call(this, data)
+    return this
+  }
+
+  setState(data){
+    SetState.call(this, data)
+    return this
+  }
+
+  simulate(data){
+    Simulate.call(this, data)
     return this
   }
 

--- a/tests/find.jsx
+++ b/tests/find.jsx
@@ -11,7 +11,7 @@ describe('Find middleware', () => {
 
   it('should find div', () => {
     Test(<TestComponent/>)
-    .use(Find, 'div')
+    .find('div')
     .test(function() {
       expect(this.helpers.elements.div[0].props.children).to.be.equal(undefined)
     })
@@ -27,7 +27,7 @@ describe('Find middleware', () => {
 
   it('should find a rendered component', () => {
     Test(<TestComponent/>)
-    .use(Find, TinyComponent)
+    .find(TinyComponent)
     .test(({helpers}) => {
       expect(helpers.elements.TinyComponent.props.test).to.be.equal('true');
     });

--- a/tests/setState.jsx
+++ b/tests/setState.jsx
@@ -16,7 +16,7 @@ describe('setState middleware', () => {
     .test(({helpers}) => {
       expect(helpers.elements.div[0].props.children).to.be.equal('test')
     })
-    .use(SetState, {test: 'changed!'})
+    .setState({test: 'changed!'})
     .test(function() {
       expect(this.component.state.test).to.be.equal('changed!')
     })

--- a/tests/simulate.jsx
+++ b/tests/simulate.jsx
@@ -25,8 +25,8 @@ describe('simulate middleware', () => {
     let spy = sinon.spy();
 
     Test(<TestComponent onClick={spy}/>)
-    .use(Find, 'button')
-    .use(Simulate, {method: 'click', element: 'button'})
+    .find('button')
+    .simulate({method: 'click', element: 'button'})
     .test(function() {
       expect(spy.called).to.be.true;
     })


### PR DESCRIPTION
Made it so `find` `simulate` and `setState` are native, ex you can do:

~~~js
Test(<Component />)
.find('div')
.setState({})
.simulate()
.test()

~~~