### PR TITLE
merge elements to root object

### DIFF
--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -37,7 +37,7 @@ class Test {
   params(){
     var length = Object.keys(this.helpers).length
     if(this.helpers.elements && length === 1) {
-      return Object.assign(this, this.helpers.elements)
+      return Object.assign({}, this, this.helpers.elements)
     }
     return this
   }

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -19,8 +19,7 @@ class Test {
       this.component = TestUtils.renderIntoDocument(component)
     }
 
-    this.middleware = []
-    this.helpers = []
+    this.helpers = {}
     return this
   }
 
@@ -30,7 +29,16 @@ class Test {
   }
 
   test(callback) {
-    callback.call(this, this)
+    var params = this.params()
+    callback.call(params, params)
+    return this
+  }
+
+  params(){
+    var length = Object.keys(this.helpers).length
+    if(this.helpers.elements && length === 1) {
+      return Object.assign(this, this.helpers.elements)
+    }
     return this
   }
 

--- a/tests/find.jsx
+++ b/tests/find.jsx
@@ -21,13 +21,20 @@ describe('Find middleware', () => {
     .test(function() {
       expect(this.helpers.elements.box.props.children).to.be.equal('found me!')
     })
+
+    Test(<TestComponent/>)
+    .use(Find, '.box')
+    .test(({box}) => {
+      expect(box.props.children).to.be.equal('found me!')
+    })
+
   });
 
   it('should find a rendered component', () => {
     Test(<TestComponent/>)
     .find(TinyComponent)
-    .test(({helpers}) => {
-      expect(helpers.elements.tinycomponent.props.test).to.be.equal('true');
+    .test(({tinycomponent}) => {
+      expect(tinycomponent.props.test).to.be.equal('true');
     });
   });
 });


### PR DESCRIPTION
This makes it WAY easy if elements are the only thing in your helpers object

From this:
~~~js
Test(<TestComponent/>)
    .use(Find, '.box')
    .test(({helpers}) => {
      expect(helpers.elements.box.props.children).to.be.equal('found me!')
    })
~~~

To this:

~~~js
Test(<TestComponent/>)
.use(Find, '.box')
.test(({box}) => {
  expect(box.props.children).to.be.equal('found me!')
})
~~~