### PR TITLE
added renderToString

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "react/sort-comp": 1,
     "react/wrap-multilines": 1,
     "new-cap": [1, {newIsCap: true, capIsNew: false}],
+    "no-underscore-dangle": 0
   },
   "plugins": [
     "react"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Test(<TestComponent onClick={spy}/>)
 ...
 
 export default function setState(state){
-  this.component.setState(state)
+  this.instance.setState(state)
 }
 ~~~
 
@@ -71,7 +71,7 @@ The `.test` function will be given the component instance and the helpers array.
 ~~~js
 .test(({helpers, component}) => { ... })
 .test(function() {
-  //this.component, this.helpers
+  //this.instance, this.helpers
 })
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 This is a super friendly testing library for React, inspired by express middleware, it's easily extendable. Why did I make this when you can use [React's Test Utils](https://facebook.github.io/react/docs/test-utils.html)? Because who likes typing out `scryRenderedDOMComponentsWithTag` and the other method names on there. Not only that, but setting up the render process is also a hassle.
 
-**New**
+###0.4.0
 
-As of **0.3.2** you can shallow render by doing `Test(<Component/>, {shallow: true})`
-
-**0.3.0** jsdom is included by default, no need to setup anything for your components to render into. The library does this all for you. Take a look at the tests directory to see examples. The big change here is that you must be on node v4 or iojs for this to work now. Also, best practice is to import this at the very top of each test file.
+In 0.4.0 there is a breaking change where `this.component` is now the component itself and the rendered instance is `this.instance`. This makes much more sense but sadly means tests need to be changed in order to update to the latest version.
 
 ###Install
 
@@ -22,7 +20,7 @@ import TestComponent from './TestComponent'
 
 let spy = sinon.spy()
 
-Test(<TestComponent onClick={spy}/>)
+Test(<TestComponent onClick={spy}/>) //or shallow render Test(<Component/>, {shallow: true})
 .find('button')
 .simulate({method: 'click', element: 'button'})
 .test(() => {
@@ -35,8 +33,8 @@ Test(<TestComponent onClick={spy}/>)
 [Current list of Middleware](https://github.com/Legitcode/tests/wiki/Bundled-Middleware)
 
 You can write middleware to do anything you repeatedly use. You can pass `.use` a function, along with an object that it will take in. Each function will be injected with the current instance which includes:
-
-- `component` - the rendered component instance
+- `component` - the actual component itself
+- `instance` - the rendered component instance
 - `helpers` - an array you can add on to with data for the end function
 
 **Example**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legit-tests",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "a chainable testing library for React",
   "main": "lib/legit-tests.js",
   "scripts": {

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -10,6 +10,7 @@ import {Find, SetState, Simulate} from './middleware'
 class Test {
 
   constructor(component, config){
+    this._component = component
     if(config && config.shallow === true){
       let shallowRenderer = TestUtils.createRenderer();
       shallowRenderer.render(component);
@@ -48,6 +49,12 @@ class Test {
 
   simulate(data){
     Simulate.call(this, data)
+    return this
+  }
+
+  renderToString(callback){
+    var component = React.renderToStaticMarkup(this._component)
+    callback.call(null, component)
     return this
   }
 

--- a/src/legit-tests.js
+++ b/src/legit-tests.js
@@ -10,14 +10,15 @@ import {Find, SetState, Simulate} from './middleware'
 class Test {
 
   constructor(component, config){
-    this._component = component
+    this.component = component
+
     if(config && config.shallow === true){
       let shallowRenderer = TestUtils.createRenderer();
       shallowRenderer.render(component);
-      this.component = shallowRenderer.getRenderOutput();
+      this.instance = shallowRenderer.getRenderOutput();
     }
     else{
-      this.component = TestUtils.renderIntoDocument(component)
+      this.instance = TestUtils.renderIntoDocument(component)
     }
 
     this.middleware = []
@@ -53,7 +54,7 @@ class Test {
   }
 
   renderToString(callback){
-    var component = React.renderToStaticMarkup(this._component)
+    var component = React.renderToStaticMarkup(this.component)
     callback.call(null, component)
     return this
   }

--- a/src/middleware/find.js
+++ b/src/middleware/find.js
@@ -5,12 +5,12 @@ export default function find(selector){
   let elements, name
   if (!(typeof selector === "string")) {
     name = selector.name.toLowerCase()
-    elements = TestUtils.scryRenderedComponentsWithType(this.component, selector)
+    elements = TestUtils.scryRenderedComponentsWithType(this.instance, selector)
   } else if (selector.match(/\./)) {
     selector = selector.replace(/\./, '')
-    elements = TestUtils.scryRenderedDOMComponentsWithClass(this.component, selector)
+    elements = TestUtils.scryRenderedDOMComponentsWithClass(this.instance, selector)
   }
-  else elements = TestUtils.scryRenderedDOMComponentsWithTag(this.component, selector)
+  else elements = TestUtils.scryRenderedDOMComponentsWithTag(this.instance, selector)
 
   if(elements.length === 1) elements = elements[0]
   if(!this.helpers.elements) this.helpers.elements = []

--- a/src/middleware/setState.js
+++ b/src/middleware/setState.js
@@ -1,3 +1,3 @@
 export default function setState(state){
-  this.component.setState(state)
+  this.instance.setState(state)
 }

--- a/tests/renderToString.jsx
+++ b/tests/renderToString.jsx
@@ -1,0 +1,18 @@
+import Test from '../src/legit-tests'
+import {Find} from '../src/middleware'
+import { expect } from 'chai';
+
+import TestComponent from './component'
+
+describe('Render To String', () => {
+
+  it('should return the html of the component', () => {
+    Test(<TestComponent test="wow"/>)
+    .test(({component}) => {
+      expect(component).to.be.ok
+    })
+    .renderToString(string => {
+      expect(string).to.match(/Click Me/)
+    })
+  });
+});

--- a/tests/renderToString.jsx
+++ b/tests/renderToString.jsx
@@ -8,11 +8,11 @@ describe('Render To String', () => {
 
   it('should return the html of the component', () => {
     Test(<TestComponent test="wow"/>)
-    .test(({component}) => {
-      expect(component).to.be.ok
-    })
     .renderToString(string => {
       expect(string).to.match(/Click Me/)
+    })
+    .test(({instance}) => {
+      expect(instance).to.be.ok
     })
   });
 });

--- a/tests/setState.jsx
+++ b/tests/setState.jsx
@@ -15,7 +15,7 @@ describe('setState middleware', () => {
     })
     .setState({test: 'changed!'})
     .test(function() {
-      expect(this.component.state.test).to.be.equal('changed!')
+      expect(this.instance.state.test).to.be.equal('changed!')
     })
   });
 

--- a/tests/shallowRender.jsx
+++ b/tests/shallowRender.jsx
@@ -9,7 +9,7 @@ describe('Shallow Render', () => {
   it('should render the component', () => {
     Test(<TestComponent test="wow"/>, {shallow: true})
     .test(function() {
-      expect(this.component).to.be.ok
+      expect(this.instance).to.be.ok
     })
   });
 

--- a/tests/shallowRender.jsx
+++ b/tests/shallowRender.jsx
@@ -3,7 +3,6 @@ import {Find} from '../src/middleware'
 import { expect } from 'chai';
 
 import TestComponent from './component'
-import TinyComponent from './tiny-component'
 
 describe('Shallow Render', () => {
 


### PR DESCRIPTION
closes #8 I'm not sure if I like this, feedback wanted:

```js
Test(<TestComponent test="wow"/>)
.renderToString(string => {
  expect(string).to.match(/Click Me/)
})
```
This also introducing a breaking, but in my opinion necessary change. `this.component` is no longer the rendered output. It is the component itself. To access the instance use `this.instance`:

```js
Test(<TestComponent />)
    .setState({test: 'changed!'})
    .test(({instance}) => {
      expect(instance.state.test).to.be.equal('changed!')
    })
```
@zbyte64