### PR TITLE
Add component to 'this' for mixins

### DIFF
--- a/src/tests.js
+++ b/src/tests.js
@@ -18,6 +18,7 @@ function Test(component, config) {
 
   const testComponent = {
     instance,
+    component,
     elements: {},
     element(select, callback) {
       let element


### PR DESCRIPTION
add component to 'this' on line 21:
```
const testComponent = {
    instance,
    component,
```

I'd like to be able to write mixins that make use of the component instance, rather than the rendered instance:

mixin I'd use:
```
function testMethod(methodName, fn){
    var bound = _.bind(this.component.type.prototype[methodName], this.component);
    fn(bound);
}

function Test(component, options={}){
    return TestUtils(component, options)
    .mixin({
        testMethod
    });
}

      it('should have a working bob method', function(){
            Test(<ComponentText data={data}/>, {shallow: true})
            .testMethod('bob', function(bob){
                expect(bob('hi')).to.equal('hi');
            });
        });
```