### PR TITLE
Fixed find middleware when selector is a component created with createClass

### DIFF
--- a/src/middleware/find.js
+++ b/src/middleware/find.js
@@ -4,7 +4,7 @@ export default function find(selector){
 
   let elements, name
   if (!(typeof selector === "string")) {
-    name = selector.name.toLowerCase()
+    name = (selector.name || selector.displayName).toLowerCase()
     elements = TestUtils.scryRenderedComponentsWithType(this.instance, selector)
   } else if (selector.match(/\./)) {
     selector = selector.replace(/\./, '')

--- a/tests/components/component.jsx
+++ b/tests/components/component.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import TinyComponent from './tiny-component'
+import OtherComponent from './other-component'
 
 export default class TestComponent extends Component {
   constructor(props, context){
@@ -23,6 +24,7 @@ export default class TestComponent extends Component {
           Click Me
         </button>
         <TinyComponent test="true"/>
+        <OtherComponent test="true"/>
       </section>
     )
   }

--- a/tests/components/other-component.jsx
+++ b/tests/components/other-component.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default React.createClass({
+  render: function() {
+    return <span className="bar"></span>
+  }
+})

--- a/tests/find.jsx
+++ b/tests/find.jsx
@@ -3,6 +3,7 @@ import { Find } from '../src/middleware'
 import { expect } from 'chai'
 
 import { TestComponent, TinyComponent } from './components'
+import OtherComponent from './components/other-component'
 
 describe('Find middleware', () => {
   it('should find div', () => {
@@ -33,6 +34,15 @@ describe('Find middleware', () => {
     .find(TinyComponent)
     .test(({tinycomponent}) => {
       expect(tinycomponent.props.test).to.be.equal('true')
+    })
+  })
+
+  it('should find a rendered component created with `createClass`', () => {
+    Test(<TestComponent/>)
+    .find(OtherComponent)
+    .test(function() {
+      let otherComponent = this.elements['other-component']
+      expect(otherComponent.props.test).to.be.equal('true')
     })
   })
 })


### PR DESCRIPTION
The `find` middleware is using the `name` property on the component class passed in as an argument which was causing an issue with components created with `React.createClass` that don't have the `name` attribute. I fixed this by falling back to `displayName` in this case.

Although using `createClass` is not the recommended way to create React components, some third-party libraries still use it, so I think the `find` middleware should support it until it's officially deprecated in React.