### PR TITLE
Add harmony-reflect as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legit-tests",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "a chainable testing library for React",
   "main": "legit-tests.js",
   "scripts": {
@@ -29,7 +29,6 @@
   "homepage": "https://github.com/legitcode/tests#readme",
   "devDependencies": {
     "alt": "^0.17.4",
-    "babel": "^5.8.23",
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",
     "expect": "^1.12.0",
-    "harmony-reflect": "^1.4.2",
     "mocha": "^2.3.3",
     "mocha-babel": "^3.0.0",
     "react-hot-loader": "^1.3.0",
@@ -47,6 +46,7 @@
   },
   "dependencies": {
     "babel": "^5.8.29",
+    "harmony-reflect": "^1.4.2",
     "jsdom": "^6.5.1",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",


### PR DESCRIPTION
This adds harmony-reflect as a dependency for the testing library. This
is needed to successfully run the tests for Alt stores, as we're using
proxies to make testing the stores more convenient.
