### PR TITLE
find now supports more css selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Test(<TestComponent onClick={spy}/>) //or shallow render Test(<Component/>, {sha
 //finding an element
 Test(<TestComponent/>)
 .find('.box')
-.test(({box}) => {
+.elements('.box', (box) => {
   /*new in 0.3.4
     if you only have elements in your helpers object, they're available in the root object
     ex: helpers.elements.box.props -> box.props, you can still use the long way :)
@@ -91,7 +91,7 @@ Test(<TestComponent/>)
 
 .find('.box')
 .find('div')
-.element('box', box => {
+.element('.box', box => {
   expect(box.props.children).to.be.equal('found me!')
 })
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ Test(<TestComponent onClick={spy}/>) //or shallow render Test(<Component/>, {sha
 Test(<TestComponent/>)
 .find('.box')
 .elements('.box', (box) => {
-  /*new in 0.3.4
-    if you only have elements in your helpers object, they're available in the root object
-    ex: helpers.elements.box.props -> box.props, you can still use the long way :)
-  */
   expect(box.props.children).to.be.equal('found me!')
 })
 ~~~

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "jsdom": "^6.5.1",
+    "lodash": "^3.10.1",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legit-tests",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "a chainable testing library for React",
   "main": "legit-tests.js",
   "scripts": {

--- a/src/middleware/find.js
+++ b/src/middleware/find.js
@@ -1,20 +1,66 @@
 import TestUtils from 'react-addons-test-utils'
+import _ from 'lodash'
 
 export default function find(selector){
 
-  let elements, name
-  if (!(typeof selector === "string")) {
-    name = selector.name.toLowerCase()
-    elements = TestUtils.scryRenderedComponentsWithType(this.instance, selector)
-  } else if (selector.match(/\./)) {
-    selector = selector.replace(/\./, '')
-    elements = TestUtils.scryRenderedDOMComponentsWithClass(this.instance, selector)
-  }
-  else elements = TestUtils.scryRenderedDOMComponentsWithTag(this.instance, selector)
+  var self = this
+  var foundElements = []
+  var elements
+  var selector
 
-  if (Array.isArray(elements) && elements.length === 1) {
-    this.elements[name || selector] = elements[0]
+  if (_.isFunction(selector)){
+    elements = TestUtils.scryRenderedComponentsWithType(this.instance, selector)
+    selector = (selector.name || selector.displayName).toLowerCase()
   } else {
-    this.elements[name || selector] = elements
+
+    var tokens = selector.split(/(?=\.)|(?=#)|(?=\[)/)
+    tokens
+    .forEach(function(subselector){
+      var els
+      switch (subselector[0]){
+        // class
+      case '.':
+        els = TestUtils.scryRenderedDOMComponentsWithClass(self.instance, subselector.slice(1))
+        foundElements.push( Array.isArray(els) ? els : [els] )
+        break
+
+      // id
+      case '#':
+        els = TestUtils.findAllInRenderedTree(self.instance, function(component){
+          if (component.id === subselector.slice(1)){
+            return true
+          }
+        })
+        foundElements.push( Array.isArray(els) ? els : [els] )
+        break
+
+      // data attribute
+      case '[':
+        els = TestUtils.findAllInRenderedTree(self.instance, function(component){
+          if (component.getAttribute) {
+            return component.getAttribute(subselector.slice(1,-1))
+          }
+        })
+        foundElements.push( Array.isArray(els) ? els : [els] )
+        break
+
+      // tag
+      default:
+        els = TestUtils.scryRenderedDOMComponentsWithTag(self.instance, subselector)
+        foundElements.push( Array.isArray(els) ? els : [els] )
+        break
+      }
+    })
+
+    elements = _.intersection.apply(_, foundElements)
   }
+
+  if (elements){
+    if (Array.isArray(elements) && elements.length === 1) {
+      this.elements[selector] = elements[0]
+    } else {
+      this.elements[selector] = elements
+    }
+  }
+
 }

--- a/tests/components/component.jsx
+++ b/tests/components/component.jsx
@@ -11,7 +11,7 @@ export default class TestComponent extends Component {
     return (
       <section>
         <div onClick={this.props.onClick}>{this.state.test}</div>
-        <p className="box">found me!</p>
+        <p className="box" data-p-tag>found me!</p>
         <button
           type="button"
           onClick={this.props.onClick}>

--- a/tests/element.jsx
+++ b/tests/element.jsx
@@ -17,7 +17,7 @@ describe('.element', () => {
     Test(<TestComponent/>)
     .find('.box')
     .find('div')
-    .element('box', box => {
+    .element('.box', box => {
       expect(box.props.children).to.be.equal('found me!')
     })
     .element('div', div => {
@@ -29,7 +29,7 @@ describe('.element', () => {
     Test(<TestComponent />)
     .find('.box')
     .find('div')
-    .element(['box', 'div'], (box, div) => {
+    .element(['.box', 'div'], (box, div) => {
       expect(div.length).to.be.equal(2)
       expect(box.props.children).to.be.equal('found me!')
     })

--- a/tests/find.jsx
+++ b/tests/find.jsx
@@ -15,15 +15,24 @@ describe('Find middleware', () => {
 
   it('should find p tag with class', () => {
     Test(<TestComponent/>)
-    .use(Find, '.box')
+    .use(Find, 'p.box')
     .test(function() {
-      expect(this.elements.box.props.children).to.be.equal('found me!')
+      expect(this.elements['p.box'].props.children).to.be.equal('found me!')
     })
 
     Test(<TestComponent/>)
-    .use(Find, '.box')
-    .test(({box}) => {
+    .use(Find, 'p.box')
+    .element('p.box',(box) => {
       expect(box.innerHTML).to.be.equal('found me!')
+    })
+
+  })
+
+  it('should find p tag with data attribute', () => {
+    Test(<TestComponent/>)
+    .use(Find, '[data-p-tag]')
+    .test(function() {
+      expect(this.elements['[data-p-tag]'].props.children).to.be.equal('found me!')
     })
 
   })


### PR DESCRIPTION
Find now can now support this:

```
.find( 'span.test-class[data-selector]' )
.test(function(){
   var text = this.elements[ ' span.test-class[data-selector]'  ].innerHTML;
});
```

However, this creates a breaking change:
Class selectors are no longer stripped of leading "." . This is for consistency that selectors simply are selectors. This means that often you need to access elements using the key syntax: `this.elements[ ".class-test"] `. This also means some fancy es6 object destructuring won't work as well. 
```
// this will no longer work
Test(<TestComponent/>)
.find('.box')
.test(({box}) => {
  expect(box.props.children).to.be.equal('found me!')
})

 // but this will
Test(<TestComponent/>)
.find('.box')
.elements('.box', (box) => {
  expect(box.props.children).to.be.equal('found me!')
})
```

I think it is VERY worth it. We've been using this project at my job, and I've found that more specific selectors are very useful for testing. I made a mixin to do this, but I also thought I'd attempt a PR with it. Tests passing, linter passing. Had to change a few tests due to the breaking changes noted above.