### PR TITLE
Allow rendering into the document.body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legit-tests",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "a chainable testing library for React",
   "main": "legit-tests.js",
   "scripts": {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,9 +1,11 @@
 import Find from './middleware/find'
 import SetState from './middleware/setState'
 import Simulate from './middleware/simulate'
+import Clean from './middleware/clean'
 
 export default {
   Find,
   SetState,
-  Simulate
+  Simulate,
+  Clean
 }

--- a/src/middleware/clean.js
+++ b/src/middleware/clean.js
@@ -1,0 +1,7 @@
+export default function Clean(){
+  this.instance = null
+  this.elements = null
+  if (global.window){
+    global.window.document.body.innerHTML = ''
+  }
+}

--- a/src/tests.js
+++ b/src/tests.js
@@ -1,9 +1,10 @@
 import TestUtils from 'react-addons-test-utils'
 import ReactDOMServer from 'react-dom/server'
+import ReactDOM from 'react-dom'
 import React from 'react'
 global.React = React
 
-import { Find, SetState, Simulate } from './middleware'
+import { Find, SetState, Simulate, Clean } from './middleware'
 
 function Test(component, config) {
 
@@ -12,6 +13,10 @@ function Test(component, config) {
     const shallowRenderer = TestUtils.createRenderer()
     shallowRenderer.render(component)
     instance = shallowRenderer.getRenderOutput()
+  } else if (config && config.fullDOM && global.window) {
+    var div = global.window.document.createElement('div')
+    global.window.document.body.appendChild(div)
+    instance = ReactDOM.render(component, div)
   } else {
     instance = TestUtils.renderIntoDocument(component)
   }
@@ -69,7 +74,8 @@ function Test(component, config) {
   return testComponent.mixin({
     find: Find,
     setState: SetState,
-    simulate: Simulate
+    simulate: Simulate,
+    clean: Clean
   })
 }
 

--- a/tests/full-dom.jsx
+++ b/tests/full-dom.jsx
@@ -7,7 +7,7 @@ describe('Render into document.body', () => {
     Test(<section />, {fullDOM: true})
     .test(function() {
       expect(global.window.document.querySelector('section'))
-      .to.be.okay
+      .to.not.equal(null)
     })
     .clean()
 

--- a/tests/full-dom.jsx
+++ b/tests/full-dom.jsx
@@ -1,0 +1,18 @@
+import Test from '../src/legit-tests'
+import { expect } from 'chai'
+
+describe('Render into document.body', () => {
+
+  it('should render and clean up component', () => {
+    Test(<section />, {fullDOM: true})
+    .test(function() {
+      expect(global.window.document.querySelector('section'))
+      .to.be.okay
+    })
+    .clean()
+
+    // clean should clean up the document.body
+    expect(global.window.document.body.innerHTML).to.equal('')
+  })
+
+})


### PR DESCRIPTION
When possible, its good to use the shallow rendering (less overhead).
Other times, we use full jsdom, but only to render into a document fragment (the default for React tests).

I've had some use cases where I actually benefited from rendering into the actual document.body of the jsdom instance. 

For example, you can't always avoid using a jquery plugin, and it's easier to test these integrations in an actual body element. Its more overhead, but it's still way way less than running something like selenium / webdriver. 

The test I added should demonstrate the API. Basically, its just a new flag, and everything else works as normal, except that you need to call `.clean()` at the end of the test.
~~~js
import Test from '../src/legit-tests'
import { expect } from 'chai'

describe('Render into document.body', () => {

  it('should render and clean up component', () => {
    Test(<section />, {fullDOM: true})
    .test(function() {
      expect(global.window.document.querySelector('section'))
      .to.be.okay
    })
    .clean()

    // clean should clean up the document.body
    expect(global.window.document.body.innerHTML).to.equal('')
  })

})
~~~